### PR TITLE
fix: use server URL for info API requests in showcase client

### DIFF
--- a/examples/showcase/client/src/scenarios/PointsReward.tsx
+++ b/examples/showcase/client/src/scenarios/PointsReward.tsx
@@ -6,6 +6,7 @@
 import { useState, useEffect } from 'react';
 import { usePayment } from '../hooks/usePayment';
 import { PaymentStatus } from '../components/PaymentStatus';
+import { buildApiUrl } from '../config';
 
 interface PointsRewardProps {
   isConnected: boolean;
@@ -26,7 +27,7 @@ export function PointsReward({ isConnected }: PointsRewardProps) {
   const { status, error, result, pay, reset } = usePayment();
 
   useEffect(() => {
-    fetch('/api/scenario-3/info')
+    fetch(buildApiUrl('/api/scenario-3/info'))
       .then((res) => res.json())
       .then((data) => setRewardInfo(data))
       .catch(console.error);

--- a/examples/showcase/client/src/scenarios/RandomNFT.tsx
+++ b/examples/showcase/client/src/scenarios/RandomNFT.tsx
@@ -6,6 +6,7 @@
 import { useState, useEffect } from 'react';
 import { usePayment } from '../hooks/usePayment';
 import { PaymentStatus } from '../components/PaymentStatus';
+import { buildApiUrl } from '../config';
 
 interface RandomNFTProps {
   isConnected: boolean;
@@ -27,7 +28,7 @@ export function RandomNFT({ isConnected, walletAddress }: RandomNFTProps) {
   const { status, error, pay, reset, result } = usePayment();
 
   useEffect(() => {
-    fetch('/api/scenario-2/info')
+    fetch(buildApiUrl('/api/scenario-2/info'))
       .then((res) => res.json())
       .then((data) => setNftInfo(data))
       .catch(console.error);


### PR DESCRIPTION
- Fix RandomNFT component to use buildApiUrl for info endpoint
- Fix PointsReward component to use buildApiUrl for info endpoint
- Ensure consistency with payment API requests which already use server URL