### PR TITLE
Add comprehensive unit tests for core_v2 guardrails (Fixes #103)

### DIFF
--- a/typescript/packages/core_v2/src/abi.test.ts
+++ b/typescript/packages/core_v2/src/abi.test.ts
@@ -1,0 +1,409 @@
+/**
+ * Tests for ABI definitions
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { SETTLEMENT_ROUTER_ABI } from "./abi";
+
+describe("abi", () => {
+  describe("SETTLEMENT_ROUTER_ABI", () => {
+    it("should export SETTLEMENT_ROUTER_ABI", () => {
+      expect(SETTLEMENT_ROUTER_ABI).toBeDefined();
+      expect(Array.isArray(SETTLEMENT_ROUTER_ABI)).toBe(true);
+    });
+
+    it("should contain the expected number of functions", () => {
+      expect(SETTLEMENT_ROUTER_ABI).toHaveLength(3);
+    });
+
+    describe("settleAndExecute function", () => {
+      let settleFunction: any;
+
+      beforeEach(() => {
+        settleFunction = SETTLEMENT_ROUTER_ABI.find(
+          (func: any) => func.name === "settleAndExecute"
+        );
+      });
+
+      it("should contain settleAndExecute function", () => {
+        expect(settleFunction).toBeDefined();
+        expect(settleFunction.type).toBe("function");
+        expect(settleFunction.name).toBe("settleAndExecute");
+      });
+
+      it("should have correct stateMutability", () => {
+        expect(settleFunction.stateMutability).toBe("nonpayable");
+      });
+
+      it("should have correct inputs count", () => {
+        expect(settleFunction.inputs).toHaveLength(12);
+      });
+
+      it("should have token input", () => {
+        const tokenInput = settleFunction.inputs.find(
+          (input: any) => input.name === "token"
+        );
+        expect(tokenInput).toBeDefined();
+        expect(tokenInput.type).toBe("address");
+      });
+
+      it("should have from input", () => {
+        const fromInput = settleFunction.inputs.find(
+          (input: any) => input.name === "from"
+        );
+        expect(fromInput).toBeDefined();
+        expect(fromInput.type).toBe("address");
+      });
+
+      it("should have value input", () => {
+        const valueInput = settleFunction.inputs.find(
+          (input: any) => input.name === "value"
+        );
+        expect(valueInput).toBeDefined();
+        expect(valueInput.type).toBe("uint256");
+      });
+
+      it("should have validAfter input", () => {
+        const validAfterInput = settleFunction.inputs.find(
+          (input: any) => input.name === "validAfter"
+        );
+        expect(validAfterInput).toBeDefined();
+        expect(validAfterInput.type).toBe("uint256");
+      });
+
+      it("should have validBefore input", () => {
+        const validBeforeInput = settleFunction.inputs.find(
+          (input: any) => input.name === "validBefore"
+        );
+        expect(validBeforeInput).toBeDefined();
+        expect(validBeforeInput.type).toBe("uint256");
+      });
+
+      it("should have nonce input", () => {
+        const nonceInput = settleFunction.inputs.find(
+          (input: any) => input.name === "nonce"
+        );
+        expect(nonceInput).toBeDefined();
+        expect(nonceInput.type).toBe("bytes32");
+      });
+
+      it("should have signature input", () => {
+        const signatureInput = settleFunction.inputs.find(
+          (input: any) => input.name === "signature"
+        );
+        expect(signatureInput).toBeDefined();
+        expect(signatureInput.type).toBe("bytes");
+      });
+
+      it("should have salt input", () => {
+        const saltInput = settleFunction.inputs.find(
+          (input: any) => input.name === "salt"
+        );
+        expect(saltInput).toBeDefined();
+        expect(saltInput.type).toBe("bytes32");
+      });
+
+      it("should have payTo input", () => {
+        const payToInput = settleFunction.inputs.find(
+          (input: any) => input.name === "payTo"
+        );
+        expect(payToInput).toBeDefined();
+        expect(payToInput.type).toBe("address");
+      });
+
+      it("should have facilitatorFee input", () => {
+        const facilitatorFeeInput = settleFunction.inputs.find(
+          (input: any) => input.name === "facilitatorFee"
+        );
+        expect(facilitatorFeeInput).toBeDefined();
+        expect(facilitatorFeeInput.type).toBe("uint256");
+      });
+
+      it("should have hook input", () => {
+        const hookInput = settleFunction.inputs.find(
+          (input: any) => input.name === "hook"
+        );
+        expect(hookInput).toBeDefined();
+        expect(hookInput.type).toBe("address");
+      });
+
+      it("should have hookData input", () => {
+        const hookDataInput = settleFunction.inputs.find(
+          (input: any) => input.name === "hookData"
+        );
+        expect(hookDataInput).toBeDefined();
+        expect(hookDataInput.type).toBe("bytes");
+      });
+
+      it("should have no outputs", () => {
+        expect(settleFunction.outputs).toHaveLength(0);
+      });
+
+      it("should have inputs in the correct order", () => {
+        const expectedOrder = [
+          "token",
+          "from",
+          "value",
+          "validAfter",
+          "validBefore",
+          "nonce",
+          "signature",
+          "salt",
+          "payTo",
+          "facilitatorFee",
+          "hook",
+          "hookData",
+        ];
+
+        expect(settleFunction.inputs.map((input: any) => input.name)).toEqual(
+          expectedOrder
+        );
+      });
+
+      it("should have the correct types in order", () => {
+        const expectedTypes = [
+          "address",
+          "address",
+          "uint256",
+          "uint256",
+          "uint256",
+          "bytes32",
+          "bytes",
+          "bytes32",
+          "address",
+          "uint256",
+          "address",
+          "bytes",
+        ];
+
+        expect(settleFunction.inputs.map((input: any) => input.type)).toEqual(
+          expectedTypes
+        );
+      });
+    });
+
+    describe("getPendingFees function", () => {
+      let getPendingFeesFunction: any;
+
+      beforeEach(() => {
+        getPendingFeesFunction = SETTLEMENT_ROUTER_ABI.find(
+          (func: any) => func.name === "getPendingFees"
+        );
+      });
+
+      it("should contain getPendingFees function", () => {
+        expect(getPendingFeesFunction).toBeDefined();
+        expect(getPendingFeesFunction.type).toBe("function");
+        expect(getPendingFeesFunction.name).toBe("getPendingFees");
+      });
+
+      it("should have correct stateMutability", () => {
+        expect(getPendingFeesFunction.stateMutability).toBe("view");
+      });
+
+      it("should have facilitator input", () => {
+        const facilitatorInput = getPendingFeesFunction.inputs.find(
+          (input: any) => input.name === "facilitator"
+        );
+        expect(facilitatorInput).toBeDefined();
+        expect(facilitatorInput.type).toBe("address");
+      });
+
+      it("should have token input", () => {
+        const tokenInput = getPendingFeesFunction.inputs.find(
+          (input: any) => input.name === "token"
+        );
+        expect(tokenInput).toBeDefined();
+        expect(tokenInput.type).toBe("address");
+      });
+
+      it("should have correct number of inputs", () => {
+        expect(getPendingFeesFunction.inputs).toHaveLength(2);
+      });
+
+      it("should have single output", () => {
+        expect(getPendingFeesFunction.outputs).toHaveLength(1);
+      });
+
+      it("should have uint256 output type", () => {
+        expect(getPendingFeesFunction.outputs[0].type).toBe("uint256");
+      });
+
+      it("should have inputs in the correct order", () => {
+        const expectedOrder = ["facilitator", "token"];
+        expect(getPendingFeesFunction.inputs.map((input: any) => input.name)).toEqual(
+          expectedOrder
+        );
+      });
+    });
+
+    describe("claimFees function", () => {
+      let claimFeesFunction: any;
+
+      beforeEach(() => {
+        claimFeesFunction = SETTLEMENT_ROUTER_ABI.find(
+          (func: any) => func.name === "claimFees"
+        );
+      });
+
+      it("should contain claimFees function", () => {
+        expect(claimFeesFunction).toBeDefined();
+        expect(claimFeesFunction.type).toBe("function");
+        expect(claimFeesFunction.name).toBe("claimFees");
+      });
+
+      it("should have correct stateMutability", () => {
+        expect(claimFeesFunction.stateMutability).toBe("nonpayable");
+      });
+
+      it("should have tokens input", () => {
+        const tokensInput = claimFeesFunction.inputs.find(
+          (input: any) => input.name === "tokens"
+        );
+        expect(tokensInput).toBeDefined();
+        expect(tokensInput.type).toBe("address[]");
+      });
+
+      it("should have correct number of inputs", () => {
+        expect(claimFeesFunction.inputs).toHaveLength(1);
+      });
+
+      it("should have no outputs", () => {
+        expect(claimFeesFunction.outputs).toHaveLength(0);
+      });
+    });
+
+    it("should only contain the expected functions", () => {
+      const functionNames = SETTLEMENT_ROUTER_ABI.map((func: any) => func.name);
+      const expectedNames = ["settleAndExecute", "getPendingFees", "claimFees"];
+
+      expect(functionNames.sort()).toEqual(expectedNames.sort());
+    });
+
+    it("should have all functions as function type", () => {
+      SETTLEMENT_ROUTER_ABI.forEach((func: any) => {
+        expect(func.type).toBe("function");
+      });
+    });
+
+    it("should have valid structure for each function", () => {
+      SETTLEMENT_ROUTER_ABI.forEach((func: any) => {
+        expect(func).toHaveProperty("type");
+        expect(func).toHaveProperty("name");
+        expect(func).toHaveProperty("inputs");
+        expect(func).toHaveProperty("outputs");
+        expect(func).toHaveProperty("stateMutability");
+
+        expect(Array.isArray(func.inputs)).toBe(true);
+        expect(Array.isArray(func.outputs)).toBe(true);
+      });
+    });
+
+    it("should have valid input structures", () => {
+      SETTLEMENT_ROUTER_ABI.forEach((func: any) => {
+        func.inputs.forEach((input: any) => {
+          expect(input).toHaveProperty("name");
+          expect(input).toHaveProperty("type");
+          expect(typeof input.name).toBe("string");
+          expect(typeof input.type).toBe("string");
+        });
+      });
+    });
+
+    it("should have valid output structures", () => {
+      SETTLEMENT_ROUTER_ABI.forEach((func: any) => {
+        func.outputs.forEach((output: any) => {
+          expect(output).toHaveProperty("type");
+          expect(typeof output.type).toBe("string");
+        });
+      });
+    });
+
+    describe("ABI validation", () => {
+      it("should match expected settleAndExecute signature", () => {
+        const settleFunction = SETTLEMENT_ROUTER_ABI.find(
+          (func: any) => func.name === "settleAndExecute"
+        );
+
+        const expectedSignature =
+          "settleAndExecute(address,address,uint256,uint256,uint256,bytes32,bytes,bytes32,address,uint256,address,bytes)";
+
+        // Generate signature from inputs
+        const inputTypes = settleFunction.inputs
+          .map((input: any) => input.type)
+          .join(",");
+        const actualSignature = `${settleFunction.name}(${inputTypes})`;
+
+        expect(actualSignature).toBe(expectedSignature);
+      });
+
+      it("should match expected getPendingFees signature", () => {
+        const getPendingFeesFunction = SETTLEMENT_ROUTER_ABI.find(
+          (func: any) => func.name === "getPendingFees"
+        );
+
+        const expectedSignature = "getPendingFees(address,address)";
+
+        // Generate signature from inputs
+        const inputTypes = getPendingFeesFunction.inputs
+          .map((input: any) => input.type)
+          .join(",");
+        const actualSignature = `${getPendingFeesFunction.name}(${inputTypes})`;
+
+        expect(actualSignature).toBe(expectedSignature);
+      });
+
+      it("should match expected claimFees signature", () => {
+        const claimFeesFunction = SETTLEMENT_ROUTER_ABI.find(
+          (func: any) => func.name === "claimFees"
+        );
+
+        const expectedSignature = "claimFees(address[])";
+
+        // Generate signature from inputs
+        const inputTypes = claimFeesFunction.inputs
+          .map((input: any) => input.type)
+          .join(",");
+        const actualSignature = `${claimFeesFunction.name}(${inputTypes})`;
+
+        expect(actualSignature).toBe(expectedSignature);
+      });
+    });
+
+    describe("ABI usage examples", () => {
+      it("should be usable for function encoding simulation", () => {
+        // This test simulates how the ABI would be used for encoding function calls
+        const settleFunction = SETTLEMENT_ROUTER_ABI.find(
+          (func: any) => func.name === "settleAndExecute"
+        );
+
+        // Verify we can extract necessary info for encoding
+        expect(settleFunction.name).toBe("settleAndExecute");
+        expect(settleFunction.inputs).toHaveLength(12);
+
+        // Verify each input has necessary properties for encoding
+        settleFunction.inputs.forEach((input: any) => {
+          expect(input.name).toBeTruthy();
+          expect(input.type).toBeTruthy();
+        });
+      });
+
+      it("should support view vs nonpayable distinction", () => {
+        const viewFunctions = SETTLEMENT_ROUTER_ABI.filter(
+          (func: any) => func.stateMutability === "view"
+        );
+        const nonpayableFunctions = SETTLEMENT_ROUTER_ABI.filter(
+          (func: any) => func.stateMutability === "nonpayable"
+        );
+
+        expect(viewFunctions).toHaveLength(1);
+        expect(nonpayableFunctions).toHaveLength(2);
+
+        expect(viewFunctions[0].name).toBe("getPendingFees");
+        expect(
+          nonpayableFunctions.map((f: any) => f.name).sort()
+        ).toEqual(["claimFees", "settleAndExecute"]);
+      });
+    });
+  });
+});

--- a/typescript/packages/core_v2/src/commitment.test.ts
+++ b/typescript/packages/core_v2/src/commitment.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Tests for commitment calculation utilities
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { checksumAddress } from "viem";
+import {
+  calculateCommitment,
+  generateSalt,
+  validateCommitmentParams,
+} from "./commitment";
+import type { CommitmentParams } from "./types";
+
+describe("commitment", () => {
+  // Mock data for testing
+  const validCommitmentParams: CommitmentParams = {
+    chainId: 84532,
+    hub: checksumAddress("0x1234567890123456789012345678901234567890"),
+    asset: checksumAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+    from: checksumAddress("0x1111111111111111111111111111111111111111"),
+    value: "1000000",
+    validAfter: "0",
+    validBefore: "1234567890",
+    salt: "0x" + "a".repeat(64),
+    payTo: checksumAddress("0x2222222222222222222222222222222222222222"),
+    facilitatorFee: "10000",
+    hook: checksumAddress("0x3333333333333333333333333333333333333333"),
+    hookData: "0x",
+  };
+
+  describe("calculateCommitment", () => {
+    it("should calculate commitment hash with valid parameters", () => {
+      const commitment = calculateCommitment(validCommitmentParams);
+
+      expect(commitment).toMatch(/^0x[0-9a-f]{64}$/);
+      expect(commitment).toHaveLength(66);
+    });
+
+    it("should produce consistent results for same parameters", () => {
+      const commitment1 = calculateCommitment(validCommitmentParams);
+      const commitment2 = calculateCommitment(validCommitmentParams);
+
+      expect(commitment1).toBe(commitment2);
+    });
+
+    it("should handle different hookData values correctly", () => {
+      const params1 = { ...validCommitmentParams, hookData: "0x1234" };
+      const params2 = { ...validCommitmentParams, hookData: "0x5678" };
+
+      const commitment1 = calculateCommitment(params1);
+      const commitment2 = calculateCommitment(params2);
+
+      expect(commitment1).not.toBe(commitment2);
+    });
+
+    it("should handle different numeric values correctly", () => {
+      const params1 = { ...validCommitmentParams, value: "1000000" };
+      const params2 = { ...validCommitmentParams, value: "2000000" };
+
+      const commitment1 = calculateCommitment(params1);
+      const commitment2 = calculateCommitment(params2);
+
+      expect(commitment1).not.toBe(commitment2);
+    });
+
+    it("should handle zero values correctly", () => {
+      const zeroValueParams = {
+        ...validCommitmentParams,
+        value: "0",
+        facilitatorFee: "0",
+        validAfter: "0",
+      };
+
+      const commitment = calculateCommitment(zeroValueParams);
+      expect(commitment).toMatch(/^0x[0-9a-f]{64}$/);
+    });
+
+    it("should handle maximum numeric values", () => {
+      const maxValueParams = {
+        ...validCommitmentParams,
+        value: "115792089237316195423570985008687907853269984665640564039457584007913129639935", // uint256 max
+        facilitatorFee: "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+        validBefore: "18446744073709551615", // uint64 max
+      };
+
+      const commitment = calculateCommitment(maxValueParams);
+      expect(commitment).toMatch(/^0x[0-9a-f]{64}$/);
+    });
+
+    it("should handle mixed case addresses", () => {
+      const mixedCaseParams = {
+        ...validCommitmentParams,
+        hub: checksumAddress("0xAbCdEf1234567890123456789012345678901234"),
+        from: checksumAddress("0xabcdefABCDEF1234567890123456789012345678"),
+      };
+
+      const commitment = calculateCommitment(mixedCaseParams);
+      expect(commitment).toMatch(/^0x[0-9a-f]{64}$/);
+    });
+  });
+
+  describe("generateSalt", () => {
+    it("should generate a 32-byte hex string", () => {
+      const salt = generateSalt();
+
+      expect(salt).toMatch(/^0x[0-9a-f]{64}$/);
+      expect(salt).toHaveLength(66);
+    });
+
+    it("should generate unique salts each time", () => {
+      const salt1 = generateSalt();
+      const salt2 = generateSalt();
+
+      expect(salt1).not.toBe(salt2);
+    });
+
+    it("should generate valid salt with proper format", () => {
+      // Test multiple generations
+      for (let i = 0; i < 5; i++) {
+        const salt = generateSalt();
+        expect(salt).toMatch(/^0x[0-9a-f]{64}$/);
+        expect(salt).toHaveLength(66);
+      }
+    });
+  });
+
+  describe("validateCommitmentParams", () => {
+    it("should pass validation for valid parameters", () => {
+      expect(() => {
+        validateCommitmentParams(validCommitmentParams);
+      }).not.toThrow();
+    });
+
+    it("should throw error for invalid hub address", () => {
+      const invalidParams = {
+        ...validCommitmentParams,
+        hub: "invalid_address",
+      };
+
+      expect(() => {
+        validateCommitmentParams(invalidParams);
+      }).toThrow("Invalid hub address");
+    });
+
+    it("should throw error for invalid asset address", () => {
+      const invalidParams = {
+        ...validCommitmentParams,
+        asset: "0xinvalid",
+      };
+
+      expect(() => {
+        validateCommitmentParams(invalidParams);
+      }).toThrow("Invalid asset address");
+    });
+
+    it("should throw error for invalid from address", () => {
+      const invalidParams = {
+        ...validCommitmentParams,
+        from: "1234567890123456789012345678901234567890", // missing 0x
+      };
+
+      expect(() => {
+        validateCommitmentParams(invalidParams);
+      }).toThrow("Invalid from address");
+    });
+
+    it("should throw error for invalid payTo address", () => {
+      const invalidParams = {
+        ...validCommitmentParams,
+        payTo: "0x123", // too short
+      };
+
+      expect(() => {
+        validateCommitmentParams(invalidParams);
+      }).toThrow("Invalid payTo address");
+    });
+
+    it("should throw error for invalid hook address", () => {
+      const invalidParams = {
+        ...validCommitmentParams,
+        hook: "0xgggggggggggggggggggggggggggggggggggggggg", // invalid hex
+      };
+
+      expect(() => {
+        validateCommitmentParams(invalidParams);
+      }).toThrow("Invalid hook address");
+    });
+
+    it("should throw error for invalid numeric value", () => {
+      const invalidParams = {
+        ...validCommitmentParams,
+        value: "not_a_number",
+      };
+
+      expect(() => {
+        validateCommitmentParams(invalidParams);
+      }).toThrow("Invalid numeric parameter");
+    });
+
+    it("should throw error for invalid validAfter", () => {
+      const invalidParams = {
+        ...validCommitmentParams,
+        validAfter: "123abc",
+      };
+
+      expect(() => {
+        validateCommitmentParams(invalidParams);
+      }).toThrow("Invalid numeric parameter");
+    });
+
+    it("should throw error for invalid validBefore", () => {
+      const invalidParams = {
+        ...validCommitmentParams,
+        validBefore: "not_a_number",
+      };
+
+      expect(() => {
+        validateCommitmentParams(invalidParams);
+      }).toThrow("Invalid numeric parameter");
+    });
+
+    it("should throw error for invalid facilitatorFee", () => {
+      const invalidParams = {
+        ...validCommitmentParams,
+        facilitatorFee: "1.5", // decimal not allowed in BigInt
+      };
+
+      expect(() => {
+        validateCommitmentParams(invalidParams);
+      }).toThrow("Invalid numeric parameter");
+    });
+
+    it("should throw error for invalid salt length", () => {
+      const invalidParams = {
+        ...validCommitmentParams,
+        salt: "0x1234", // too short
+      };
+
+      expect(() => {
+        validateCommitmentParams(invalidParams);
+      }).toThrow("Invalid salt: must be bytes32 (0x + 64 hex chars)");
+    });
+
+    it("should throw error for invalid salt format", () => {
+      const invalidParams = {
+        ...validCommitmentParams,
+        salt: "1234" + "a".repeat(64), // missing 0x
+      };
+
+      expect(() => {
+        validateCommitmentParams(invalidParams);
+      }).toThrow("Invalid salt: must be bytes32 (0x + 64 hex chars)");
+    });
+
+    it("should throw error for invalid hookData format", () => {
+      const invalidParams = {
+        ...validCommitmentParams,
+        hookData: "not_hex",
+      };
+
+      expect(() => {
+        validateCommitmentParams(invalidParams);
+      }).toThrow("Invalid hookData: must be hex string");
+    });
+
+    it("should accept empty hookData", () => {
+      const validParams = {
+        ...validCommitmentParams,
+        hookData: "0x",
+      };
+
+      expect(() => {
+        validateCommitmentParams(validParams);
+      }).not.toThrow();
+    });
+
+    it("should accept valid hex hookData", () => {
+      const validParams = {
+        ...validCommitmentParams,
+        hookData: "0x1234567890abcdef",
+      };
+
+      expect(() => {
+        validateCommitmentParams(validParams);
+      }).not.toThrow();
+    });
+
+    it("should accept zero address for hook (no hook case)", () => {
+      const validParams = {
+        ...validCommitmentParams,
+        hook: "0x0000000000000000000000000000000000000000",
+      };
+
+      expect(() => {
+        validateCommitmentParams(validParams);
+      }).not.toThrow();
+    });
+
+    it("should validate mixed case addresses correctly", () => {
+      const mixedCaseParams = {
+        ...validCommitmentParams,
+        hub: checksumAddress("0xAbCdEf1234567890123456789012345678901234"),
+        asset: checksumAddress("0xabcdefABCDEF1234567890123456789012345678"),
+        from: checksumAddress("0x1111111111111111111111111111111111111111"),
+        payTo: checksumAddress("0x2222222222222222222222222222222222222222"),
+        hook: checksumAddress("0x3333333333333333333333333333333333333333"),
+      };
+
+      expect(() => {
+        validateCommitmentParams(mixedCaseParams);
+      }).not.toThrow();
+    });
+
+    it("should handle very large numeric values", () => {
+      const largeNumberParams = {
+        ...validCommitmentParams,
+        value: "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+        facilitatorFee: "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      };
+
+      expect(() => {
+        validateCommitmentParams(largeNumberParams);
+      }).not.toThrow();
+    });
+  });
+
+  describe("integration tests", () => {
+    it("should generate salt and use it in commitment calculation", () => {
+      const salt = generateSalt();
+      const params = { ...validCommitmentParams, salt };
+
+      expect(() => {
+        validateCommitmentParams(params);
+      }).not.toThrow();
+
+      const commitment = calculateCommitment(params);
+      expect(commitment).toMatch(/^0x[0-9a-f]{64}$/);
+    });
+
+    it("should produce different commitments for different salts", () => {
+      const salt1 = generateSalt();
+      const salt2 = generateSalt();
+
+      const params1 = { ...validCommitmentParams, salt: salt1 };
+      const params2 = { ...validCommitmentParams, salt: salt2 };
+
+      const commitment1 = calculateCommitment(params1);
+      const commitment2 = calculateCommitment(params2);
+
+      expect(commitment1).not.toBe(commitment2);
+    });
+
+    it("should handle complete workflow with validation and calculation", () => {
+      const customSalt = generateSalt();
+      const params: CommitmentParams = {
+        chainId: 1,
+        hub: checksumAddress("0x1234567890123456789012345678901234567890"),
+        asset: checksumAddress("0xA0b86a33E6441e2a5C3e23e3C7D1D3e3D9a1C8b9"),
+        from: checksumAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+        value: "500000000", // 500 USDC (6 decimals)
+        validAfter: Math.floor(Date.now() / 1000).toString(),
+        validBefore: (Math.floor(Date.now() / 1000) + 3600).toString(),
+        salt: customSalt,
+        payTo: checksumAddress("0x5555555555555555555555555555555555555555"),
+        facilitatorFee: "5000000", // 5 USDC fee
+        hook: checksumAddress("0x6666666666666666666666666666666666666666"),
+        hookData: "0x1234567890abcdef",
+      };
+
+      expect(() => {
+        validateCommitmentParams(params);
+      }).not.toThrow();
+
+      const commitment = calculateCommitment(params);
+      expect(commitment).toMatch(/^0x[0-9a-f]{64}$/);
+    });
+  });
+});

--- a/typescript/packages/core_v2/src/hooks.test.ts
+++ b/typescript/packages/core_v2/src/hooks.test.ts
@@ -1,0 +1,561 @@
+/**
+ * Tests for hooks utilities
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { TransferHook, NFTMintHook, RewardHook } from "./hooks";
+import type { Split } from "./hooks/transfer";
+import { checksumAddress } from "viem";
+
+// Mock getNetworkConfig function
+vi.mock("./networks", () => ({
+  getNetworkConfig: vi.fn((network: string) => {
+    if (network === "base-sepolia") {
+      return {
+        hooks: {
+          transfer: "0x4DE234059C6CcC94B8fE1eb1BD24804794083569",
+        },
+        demoHooks: {
+          nftMint: "0x742d35Cc6634C0532925a3b8D4C9db96C4b4Db45",
+          randomNFT: "0x8ba1f109551bD432803012645Hac136c",
+          reward: "0x9ba1f109551bD432803012645Hac136d",
+          rewardToken: "0xaba1f109551bD432803012645Hac136e",
+        },
+      };
+    } else if (network === "mainnet") {
+      return {
+        hooks: {
+          transfer: "0x1A2b3c4D5e6F7a8B9c0D1e2F3a4B5c6D7E8F9a0B",
+        },
+        demoHooks: {
+          nftMint: "0x2A3b4c5D6e7F8a9B0c1D2e3F4a5B6c7D8E9F0a1C",
+          randomNFT: "0x3B4c5d6E7f8A9b0C1d2E3f4A5b6C7d8E9f0A1b2",
+          reward: "0x4C5d6e7F8a9B0c1D2e3F4a5B6c7D8E9f0A1b2C3",
+          rewardToken: "0x5D6e7F8a9b0C1d2E3f4A5b6C7d8E9f0A1b2C3D4",
+        },
+      };
+    }
+    throw new Error(`Network "${network}" not found`);
+  }),
+}));
+
+describe("hooks", () => {
+  const validAddress = checksumAddress("0x1234567890123456789012345678901234567890");
+
+  describe("TransferHook", () => {
+    describe("encode", () => {
+      it("should return '0x' for simple transfer (no splits)", () => {
+        const result = TransferHook.encode();
+        expect(result).toBe("0x");
+      });
+
+      it("should return '0x' for empty splits array", () => {
+        const result = TransferHook.encode([]);
+        expect(result).toBe("0x");
+      });
+
+      it("should encode single split correctly", () => {
+        const splits: Split[] = [
+          {
+            recipient: validAddress,
+            bips: 10000, // 100%
+          },
+        ];
+
+        const result = TransferHook.encode(splits);
+
+        expect(result).toMatch(/^0x[0-9a-f]+$/); // Should be ABI encoded
+        expect(result).not.toBe("0x");
+        expect(result.length).toBeGreaterThan(64); // Should be longer than just a hash
+      });
+
+      it("should encode multiple splits correctly", () => {
+        const splits: Split[] = [
+          {
+            recipient: checksumAddress("0x1234567890123456789012345678901234567890"),
+            bips: 6000, // 60%
+          },
+          {
+            recipient: checksumAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+            bips: 4000, // 40%
+          },
+        ];
+
+        const result = TransferHook.encode(splits);
+
+        expect(result).toMatch(/^0x[0-9a-f]+$/);
+        expect(result).not.toBe("0x");
+      });
+
+      it("should encode partial splits correctly", () => {
+        const splits: Split[] = [
+          {
+            recipient: validAddress,
+            bips: 3000, // 30%
+          },
+        ];
+
+        const result = TransferHook.encode(splits);
+
+        expect(result).toMatch(/^0x[0-9a-f]+$/);
+        expect(result).not.toBe("0x");
+      });
+
+      it("should throw error for invalid recipient address (empty string)", () => {
+        const splits: Split[] = [
+          {
+            recipient: "",
+            bips: 1000,
+          },
+        ];
+
+        expect(() => {
+          TransferHook.encode(splits);
+        }).toThrow("Invalid recipient address: ");
+      });
+
+      it("should throw error for zero address", () => {
+        const splits: Split[] = [
+          {
+            recipient: "0x0000000000000000000000000000000000000000",
+            bips: 1000,
+          },
+        ];
+
+        expect(() => {
+          TransferHook.encode(splits);
+        }).toThrow("Invalid recipient address: 0x0000000000000000000000000000000000000000");
+      });
+
+      it("should throw error for zero bips", () => {
+        const splits: Split[] = [
+          {
+            recipient: validAddress,
+            bips: 0,
+          },
+        ];
+
+        expect(() => {
+          TransferHook.encode(splits);
+        }).toThrow("Bips must be greater than 0, got: 0");
+      });
+
+      it("should throw error for negative bips", () => {
+        const splits: Split[] = [
+          {
+            recipient: validAddress,
+            bips: -100,
+          },
+        ];
+
+        expect(() => {
+          TransferHook.encode(splits);
+        }).toThrow("Bips must be greater than 0, got: -100");
+      });
+
+      it("should throw error for bips exceeding 10000", () => {
+        const splits: Split[] = [
+          {
+            recipient: validAddress,
+            bips: 10001,
+          },
+        ];
+
+        expect(() => {
+          TransferHook.encode(splits);
+        }).toThrow("Individual bips cannot exceed 10000, got: 10001");
+      });
+
+      it("should throw error for total bips exceeding 10000", () => {
+        const splits: Split[] = [
+          {
+            recipient: validAddress,
+            bips: 6000,
+          },
+          {
+            recipient: checksumAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+            bips: 5000, // Total = 11000 > 10000
+          },
+        ];
+
+        expect(() => {
+          TransferHook.encode(splits);
+        }).toThrow("Total bips (11000) exceeds 10000 (100%)");
+      });
+
+      it("should accept total bips equal to 10000", () => {
+        const splits: Split[] = [
+          {
+            recipient: validAddress,
+            bips: 7000,
+          },
+          {
+            recipient: checksumAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+            bips: 3000, // Total = 10000
+          },
+        ];
+
+        expect(() => {
+          const result = TransferHook.encode(splits);
+          expect(result).toMatch(/^0x[0-9a-f]+$/);
+        }).not.toThrow();
+      });
+
+      it("should accept total bips less than 10000", () => {
+        const splits: Split[] = [
+          {
+            recipient: validAddress,
+            bips: 2000,
+          },
+          {
+            recipient: checksumAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+            bips: 1000, // Total = 3000 < 10000
+          },
+        ];
+
+        expect(() => {
+          const result = TransferHook.encode(splits);
+          expect(result).toMatch(/^0x[0-9a-f]+$/);
+        }).not.toThrow();
+      });
+
+      it("should handle mixed case recipient addresses", () => {
+        const splits: Split[] = [
+          {
+            recipient: checksumAddress("0xAbCdEf1234567890123456789012345678901234"),
+            bips: 5000,
+          },
+        ];
+
+        expect(() => {
+          const result = TransferHook.encode(splits);
+          expect(result).toMatch(/^0x[0-9a-f]+$/);
+        }).not.toThrow();
+      });
+
+      it("should handle single bips correctly", () => {
+        const splits: Split[] = [
+          {
+            recipient: validAddress,
+            bips: 1, // 0.01%
+          },
+        ];
+
+        expect(() => {
+          const result = TransferHook.encode(splits);
+          expect(result).toMatch(/^0x[0-9a-f]+$/);
+        }).not.toThrow();
+      });
+
+      it("should produce consistent encoding for same splits", () => {
+        const splits: Split[] = [
+          {
+            recipient: validAddress,
+            bips: 6000,
+          },
+          {
+            recipient: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+            bips: 4000,
+          },
+        ];
+
+        const result1 = TransferHook.encode(splits);
+        const result2 = TransferHook.encode(splits);
+
+        expect(result1).toBe(result2);
+      });
+
+      it("should produce different encodings for different splits", () => {
+        const splits1: Split[] = [
+          {
+            recipient: validAddress,
+            bips: 5000,
+          },
+        ];
+
+        const splits2: Split[] = [
+          {
+            recipient: validAddress,
+            bips: 6000,
+          },
+        ];
+
+        const result1 = TransferHook.encode(splits1);
+        const result2 = TransferHook.encode(splits2);
+
+        expect(result1).not.toBe(result2);
+      });
+    });
+
+    describe("getAddress", () => {
+      it("should return TransferHook address for supported network", () => {
+        const address = TransferHook.getAddress("base-sepolia");
+        expect(address).toBe("0x4DE234059C6CcC94B8fE1eb1BD24804794083569");
+      });
+
+      it("should return different addresses for different networks", () => {
+        const address1 = TransferHook.getAddress("base-sepolia");
+        const address2 = TransferHook.getAddress("mainnet");
+
+        expect(address1).not.toBe(address2);
+        expect(address1).toBe("0x4DE234059C6CcC94B8fE1eb1BD24804794083569");
+        expect(address2).toBe("0x1A2b3c4D5e6F7a8B9c0D1e2F3a4B5c6D7E8F9a0B");
+      });
+
+      it("should throw error for unsupported network", () => {
+        expect(() => {
+          TransferHook.getAddress("unsupported-network");
+        }).toThrow('Network "unsupported-network" not found');
+      });
+    });
+  });
+
+  describe("NFTMintHook", () => {
+    describe("getAddress", () => {
+      it("should return NFTMintHook address for supported network", () => {
+        const address = NFTMintHook.getAddress("base-sepolia");
+        expect(address).toBe("0x742d35Cc6634C0532925a3b8D4C9db96C4b4Db45");
+      });
+
+      it("should return different addresses for different networks", () => {
+        const address1 = NFTMintHook.getAddress("base-sepolia");
+        const address2 = NFTMintHook.getAddress("mainnet");
+
+        expect(address1).not.toBe(address2);
+        expect(address1).toBe("0x742d35Cc6634C0532925a3b8D4C9db96C4b4Db45");
+        expect(address2).toBe("0x2A3b4c5D6e7F8a9B0c1D2e3F4a5B6c7D8E9F0a1C");
+      });
+
+      it("should throw error for network without demo hooks", () => {
+        expect(() => {
+          NFTMintHook.getAddress("unsupported-network");
+        }).toThrow('Network "unsupported-network" not found');
+      });
+    });
+
+    describe("getNFTContractAddress", () => {
+      it("should return NFT contract address for supported network", () => {
+        const address = NFTMintHook.getNFTContractAddress("base-sepolia");
+        expect(address).toBe("0x8ba1f109551bD432803012645Hac136c");
+      });
+
+      it("should return different addresses for different networks", () => {
+        const address1 = NFTMintHook.getNFTContractAddress("base-sepolia");
+        const address2 = NFTMintHook.getNFTContractAddress("mainnet");
+
+        expect(address1).not.toBe(address2);
+        expect(address1).toBe("0x8ba1f109551bD432803012645Hac136c");
+        expect(address2).toBe("0x3B4c5d6E7f8A9b0C1d2E3f4A5b6C7d8E9f0A1b2");
+      });
+
+      it("should throw error for network without demo hooks", () => {
+        expect(() => {
+          NFTMintHook.getNFTContractAddress("unsupported-network");
+        }).toThrow('Network "unsupported-network" not found');
+      });
+    });
+
+    describe("encode", () => {
+      it("should encode mint config correctly", () => {
+        const config = {
+          nftContract: validAddress,
+        };
+
+        const result = NFTMintHook.encode(config);
+
+        expect(result).toMatch(/^0x[0-9a-f]+$/);
+        expect(result).not.toBe("0x");
+      });
+
+      it("should encode different addresses to different results", () => {
+        const config1 = {
+          nftContract: checksumAddress("0x1234567890123456789012345678901234567890"),
+        };
+
+        const config2 = {
+          nftContract: checksumAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+        };
+
+        const result1 = NFTMintHook.encode(config1);
+        const result2 = NFTMintHook.encode(config2);
+
+        expect(result1).not.toBe(result2);
+      });
+
+      it("should produce consistent encoding for same config", () => {
+        const config = {
+          nftContract: validAddress,
+        };
+
+        const result1 = NFTMintHook.encode(config);
+        const result2 = NFTMintHook.encode(config);
+
+        expect(result1).toBe(result2);
+      });
+
+      it("should handle mixed case addresses", () => {
+        const config = {
+          nftContract: checksumAddress("0xAbCdEf1234567890123456789012345678901234"),
+        };
+
+        expect(() => {
+          const result = NFTMintHook.encode(config);
+          expect(result).toMatch(/^0x[0-9a-f]+$/);
+        }).not.toThrow();
+      });
+    });
+  });
+
+  describe("RewardHook", () => {
+    describe("getAddress", () => {
+      it("should return RewardHook address for supported network", () => {
+        const address = RewardHook.getAddress("base-sepolia");
+        expect(address).toBe("0x9ba1f109551bD432803012645Hac136d");
+      });
+
+      it("should return different addresses for different networks", () => {
+        const address1 = RewardHook.getAddress("base-sepolia");
+        const address2 = RewardHook.getAddress("mainnet");
+
+        expect(address1).not.toBe(address2);
+        expect(address1).toBe("0x9ba1f109551bD432803012645Hac136d");
+        expect(address2).toBe("0x4C5d6e7F8a9B0c1D2e3F4a5B6c7D8E9f0A1b2C3");
+      });
+
+      it("should throw error for network without demo hooks", () => {
+        expect(() => {
+          RewardHook.getAddress("unsupported-network");
+        }).toThrow('Network "unsupported-network" not found');
+      });
+    });
+
+    describe("getTokenAddress", () => {
+      it("should return reward token address for supported network", () => {
+        const address = RewardHook.getTokenAddress("base-sepolia");
+        expect(address).toBe("0xaba1f109551bD432803012645Hac136e");
+      });
+
+      it("should return different addresses for different networks", () => {
+        const address1 = RewardHook.getTokenAddress("base-sepolia");
+        const address2 = RewardHook.getTokenAddress("mainnet");
+
+        expect(address1).not.toBe(address2);
+        expect(address1).toBe("0xaba1f109551bD432803012645Hac136e");
+        expect(address2).toBe("0x5D6e7F8a9b0C1d2E3f4A5b6C7d8E9f0A1b2C3D4");
+      });
+
+      it("should throw error for network without demo hooks", () => {
+        expect(() => {
+          RewardHook.getTokenAddress("unsupported-network");
+        }).toThrow('Network "unsupported-network" not found');
+      });
+    });
+
+    describe("encode", () => {
+      it("should encode reward config correctly", () => {
+        const config = {
+          rewardToken: validAddress,
+        };
+
+        const result = RewardHook.encode(config);
+
+        expect(result).toMatch(/^0x[0-9a-f]+$/);
+        expect(result).not.toBe("0x");
+      });
+
+      it("should encode different addresses to different results", () => {
+        const config1 = {
+          rewardToken: checksumAddress("0x1234567890123456789012345678901234567890"),
+        };
+
+        const config2 = {
+          rewardToken: checksumAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+        };
+
+        const result1 = RewardHook.encode(config1);
+        const result2 = RewardHook.encode(config2);
+
+        expect(result1).not.toBe(result2);
+      });
+
+      it("should produce consistent encoding for same config", () => {
+        const config = {
+          rewardToken: validAddress,
+        };
+
+        const result1 = RewardHook.encode(config);
+        const result2 = RewardHook.encode(config);
+
+        expect(result1).toBe(result2);
+      });
+
+      it("should handle mixed case addresses", () => {
+        const config = {
+          rewardToken: checksumAddress("0xAbCdEf1234567890123456789012345678901234"),
+        };
+
+        expect(() => {
+          const result = RewardHook.encode(config);
+          expect(result).toMatch(/^0x[0-9a-f]+$/);
+        }).not.toThrow();
+      });
+    });
+  });
+
+  describe("integration tests", () => {
+    it("should work with TransferHook simple transfer scenario", () => {
+      const hookData = TransferHook.encode(); // Simple transfer
+      const address = TransferHook.getAddress("base-sepolia");
+
+      expect(hookData).toBe("0x");
+      expect(address).toBe("0x4DE234059C6CcC94B8fE1eb1BD24804794083569");
+    });
+
+    it("should work with TransferHook distributed transfer scenario", () => {
+      const splits: Split[] = [
+        {
+          recipient: checksumAddress("0x1234567890123456789012345678901234567890"),
+          bips: 7000, // 70%
+        },
+        {
+          recipient: checksumAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+          bips: 3000, // 30%
+        },
+      ];
+
+      const hookData = TransferHook.encode(splits);
+      const address = TransferHook.getAddress("base-sepolia");
+
+      expect(hookData).toMatch(/^0x[0-9a-f]+$/);
+      expect(address).toBe("0x4DE234059C6CcC94B8fE1eb1BD24804794083569");
+    });
+
+    it("should work with NFTMintHook complete scenario", () => {
+      const config = {
+        nftContract: checksumAddress("0x1234567890123456789012345678901234567890"),
+      };
+
+      const hookData = NFTMintHook.encode(config);
+      const address = NFTMintHook.getAddress("base-sepolia");
+      const nftContract = NFTMintHook.getNFTContractAddress("base-sepolia");
+
+      expect(hookData).toMatch(/^0x[0-9a-f]+$/);
+      expect(address).toBe("0x742d35Cc6634C0532925a3b8D4C9db96C4b4Db45");
+      expect(nftContract).toBe("0x8ba1f109551bD432803012645Hac136c");
+    });
+
+    it("should work with RewardHook complete scenario", () => {
+      const config = {
+        rewardToken: checksumAddress("0x1234567890123456789012345678901234567890"),
+      };
+
+      const hookData = RewardHook.encode(config);
+      const address = RewardHook.getAddress("base-sepolia");
+      const tokenAddress = RewardHook.getTokenAddress("base-sepolia");
+
+      expect(hookData).toMatch(/^0x[0-9a-f]+$/);
+      expect(address).toBe("0x9ba1f109551bD432803012645Hac136d");
+      expect(tokenAddress).toBe("0xaba1f109551bD432803012645Hac136e");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added comprehensive unit tests for commitment calculation, validation, and salt generation
- Added extensive unit tests for hooks functionality (TransferHook, NFTMintHook, RewardHook)
- Added detailed unit tests for ABI definitions and structure validation
- All tests pass with 100% success rate (180 tests)

## Test Plan
- [x] Run all unit tests for core_v2 package - **PASSING** (180/180 tests)
- [x] Verify commitment calculation and validation functionality - **COVERED**
- [x] Test hooks encoding/decoding and address lookup - **COVERED**
- [x] Validate ABI structure and function signatures - **COVERED**
- [x] Ensure proper address validation using checksumAddress - **COVERED**

## Changes
- `src/commitment.test.ts` - Comprehensive tests for commitment functionality
- `src/hooks.test.ts` - Complete test coverage for TransferHook, NFTMintHook, and RewardHook
- `src/abi.test.ts` - Detailed tests for SETTLEMENT_ROUTER_ABI structure

This implementation resolves the missing unit tests issue for core_v2 guardrails mentioned in #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)